### PR TITLE
added cancer dataset within the data stage

### DIFF
--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -49,6 +49,12 @@ stages:
         repository:
           url: "https://github.com/lorenzo-22/synthetic_dataset"
           commit: 0db1a6b
+      - id: s2
+        name: 'cancer_data'
+        software_environment: "python"
+        repository:
+          url: "https://github.com/lorenzo-22/cancer_dataset"
+          commit: b21bb12
     outputs:
       - id: data.matrix
         path: "{input}/{stage}/{module}/{params}/{dataset}.synthetic_dataset.csv"
@@ -56,7 +62,6 @@ stages:
         path: "{input}/{stage}/{module}/{params}/{dataset}.true_labels.csv"
       - id: data.true_labels_proteins
         path: "{input}/{stage}/{module}/{params}/{dataset}.true_labels_proteins.csv"
-
   ## Methods
   - id: methods
     modules:
@@ -65,7 +70,7 @@ stages:
         software_environment: "r_limma"
         repository:
           url: "https://github.com/JosefineTM/DDA_limma"
-          commit: 5b36df8    
+          commit:  423f115  
       - id: welch
         name: "welch_ttest"
         software_environment: "python_basic"


### PR DESCRIPTION
Added the cancer dataset in the benchmark.yml file. The run works fine and produce all the results. 
Things to address:

- The output section of the data stage can only be defined once for all the data modules. This means that the naming in the output path should be generalized for consistency (i.e. `{input}/{stage}/{module}/{params}/{dataset}.synthetic_dataset.csv` can be changed in `{input}/{stage}/{module}/{params}/{dataset}._dataset.csv`.
- The cancer dataset should not produce any protein true label since it doesnt hold a ground truth and the intra metrics should not be computed on this dataset. For simplicity, I added- in the cancer data generation script- a dummy dataframe that gives in output a fake protein true label csv so we don't have error in the downstream metrics. We coudl potentially leave it like that and ignore the output of the intra metrics on this dataset